### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements
-        run: pip install -r requirements_frozen.txt
+        run: pip install -c constraints.txt -r requirements_frozen.txt
       - name: Run tests
         run: pytest

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+importlib-metadata<5.0

--- a/marge/job.py
+++ b/marge/job.py
@@ -9,7 +9,7 @@ from . import git, gitlab
 from .branch import Branch
 from .interval import IntervalUnion
 from .merge_request import MergeRequestRebaseFailed
-from .project import Project
+from .project import Project, SquashOption
 from .user import User
 from .pipeline import Pipeline
 
@@ -48,7 +48,7 @@ class MergeJob:
             raise CannotMerge("Sorry, I can't merge requests marked as Work-In-Progress!")
 
         auto_squash = (
-            self._project.squash_enforced or
+            self._project.squash_option is SquashOption.always or
             merge_request.squash
         )
 

--- a/marge/project.py
+++ b/marge/project.py
@@ -1,5 +1,5 @@
 import logging as log
-from enum import IntEnum, unique
+from enum import Enum, IntEnum, unique
 from functools import partial
 
 from . import gitlab
@@ -91,7 +91,7 @@ class Project(gitlab.Resource):
 
     @property
     def squash_option(self):
-        return self.info.get('squash_option', None)
+        return SquashOption(self.info['squash_option'])
 
     @property
     def only_allow_merge_if_pipeline_succeeds(self):
@@ -116,10 +116,6 @@ class Project(gitlab.Resource):
         assert effective_access is not None, "GitLab failed to provide user permissions on project"
         return AccessLevel(effective_access['access_level'])
 
-    @property
-    def squash_enforced(self):
-        return self.squash_option == 'always'
-
 
 # pylint: disable=invalid-name
 @unique
@@ -132,3 +128,11 @@ class AccessLevel(IntEnum):
     developer = 30
     maintainer = 40
     owner = 50
+
+
+@unique
+class SquashOption(str, Enum):
+    always = "always"
+    default_off = "default_off"
+    default_on = "default_on"
+    never = "never"

--- a/marge/single_merge_job.py
+++ b/marge/single_merge_job.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from . import git, gitlab
 from .commit import Commit
 from .job import CannotMerge, GitLabRebaseResultMismatch, MergeJob, SkipMerge
+from .project import SquashOption
 
 
 class SingleMergeJob(MergeJob):
@@ -92,7 +93,7 @@ class SingleMergeJob(MergeJob):
 
             self.ensure_mergeable_mr(merge_request)
 
-            auto_squash = True if target_project.squash_enforced else None
+            auto_squash = True if target_project.squash_option is SquashOption.always else None
 
             try:
                 ret = merge_request.accept(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -152,7 +152,6 @@ class TestJob:
             work_in_progress=False,
             squash=True,
         )
-        merge_request.fetch_approvals.return_value.sufficient = True
         with pytest.raises(CannotMerge) as exc_info:
             merge_job.ensure_mergeable_mr(merge_request)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -165,7 +165,7 @@ class TestJob:
             project=create_autospec(
                 marge.project.Project,
                 spec_set=True,
-                squash_option="always",
+                squash_option=marge.project.SquashOption.always,
             ),
             options=MergeJobOptions.default(add_reviewers=True),
         )

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -144,8 +144,16 @@ class TestJob:
 
         assert exc_info.value.reason == "Sorry, I can't merge requests which have unresolved discussions!"
 
-    def test_ensure_mergeable_mr_squash_and_trailers(self):
-        merge_job = self.get_merge_job(options=MergeJobOptions.default(add_reviewers=True))
+    @pytest.mark.parametrize('squash_option', marge.project.SquashOption)
+    def test_ensure_mergeable_mr_squash_wanted_and_trailers(self, squash_option):
+        merge_job = self.get_merge_job(
+            project=create_autospec(
+                marge.project.Project,
+                spec_set=True,
+                squash_option=squash_option,
+            ),
+            options=MergeJobOptions.default(add_reviewers=True)
+        )
         merge_request = self._mock_merge_request(
             assignee_ids=[merge_job._user.id],
             state='opened',

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -160,6 +160,29 @@ class TestJob:
                                      "would ruin my commit tagging!"
         )
 
+    def test_ensure_mergeable_mr_squash_needed_and_trailers(self):
+        merge_job = self.get_merge_job(
+            project=create_autospec(
+                marge.project.Project,
+                spec_set=True,
+                squash_option="always",
+            ),
+            options=MergeJobOptions.default(add_reviewers=True),
+        )
+        merge_request = self._mock_merge_request(
+            assignee_ids=[merge_job._user.id],
+            state='opened',
+            work_in_progress=False,
+            squash=False,
+        )
+        with pytest.raises(CannotMerge) as exc_info:
+            merge_job.ensure_mergeable_mr(merge_request)
+
+        assert (
+            exc_info.value.reason == "Sorry, merging requests marked as auto-squash "
+                                     "would ruin my commit tagging!"
+        )
+
     def test_unassign_from_mr(self):
         merge_job = self.get_merge_job()
         merge_request = self._mock_merge_request()

--- a/tests/test_merge_request.py
+++ b/tests/test_merge_request.py
@@ -161,6 +161,32 @@ class TestMergeRequest:
         self.merge_request.rebase()
         self.api.call.assert_has_calls([call(req) for (req, resp) in expected])
 
+    @pytest.mark.parametrize('squash_wanted', [True, False])
+    def test_accept_auto_squash_is_boolean(self, squash_wanted):
+        self._load(dict(INFO, sha='badc0de'))
+        self.merge_request.accept(auto_squash=squash_wanted)
+        self.api.call.assert_called_once_with(PUT(
+            '/projects/1234/merge_requests/54/merge',
+            dict(
+                merge_when_pipeline_succeeds=True,
+                should_remove_source_branch=False,
+                sha='badc0de',
+                squash=squash_wanted,
+            )
+        ))
+
+    def test_accept_auto_squash_is_none(self):
+        self._load(dict(INFO, sha='badc0de'))
+        self.merge_request.accept(auto_squash=None)
+        self.api.call.assert_called_once_with(PUT(
+            '/projects/1234/merge_requests/54/merge',
+            dict(
+                merge_when_pipeline_succeeds=True,
+                should_remove_source_branch=False,
+                sha='badc0de',
+            )
+        ))
+
     def test_accept_remove_branch(self):
         self._load(dict(INFO, sha='badc0de'))
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -20,7 +20,8 @@ INFO = {
         'group_access': {
             'access_level': AccessLevel.developer.value,
         }
-    }
+    },
+    'squash_option': 'default_off',
 }
 
 GROUP_ACCESS = {
@@ -109,6 +110,7 @@ class TestProject:
         assert project.merge_requests_enabled is True
         assert project.only_allow_merge_if_pipeline_succeeds is True
         assert project.only_allow_merge_if_all_discussions_are_resolved is False
+        assert project.squash_option == 'default_off'
         assert project.access_level == AccessLevel.developer
 
     def test_group_access(self):


### PR DESCRIPTION
I took the liberty of removing the `squash_enforced` property (in order to a) reduce the footprint of the `Project` class; and b) to simplify the mocking), and replaced the "encapsulation" with an enum.

Also had to fix some pip dependencies, otherwise the CI test suites wouldn't run at all.